### PR TITLE
Fix calibration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3]
+### Changed
+- Fix the logic to figure out when calibration is required. ([#14](https://github.com/metrics-rs/quanta/pull/14))
+
+## [0.5.1] - 2020-04-11
+### Changed
+- Small tweak to the docs.
+
+## [0.5.0] - 2020-04-11
+### Changed
+- Switch to `mach` for macOS/iOS as it was deprecated in `libc`. ([#12](https://github.com/metrics-rs/quanta/pull/12))
+- Switch to `core::arch` for instrinics, and drop the feature flagged configuration to use it. ([#12](https://github.com/metrics-rs/quanta/pull/12))
+- Switch to `criterion` for benchmarking. ([#12](https://github.com/metrics-rs/quanta/pull/12))
+
+## [0.4.0] - 2020-02-20
+### Changed
+- Differentiate between raw and scaled time by adding a new `Instant` type. ([#10](https://github.com/metrics-rs/quanta/pull/10))
+
 ## [0.2.0] - 2019-03-10
 ### Changed
 - Fixed support for Windows.  It was in a bad way, but actually works correctly now!

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,5 +39,6 @@ mach = "^0.3"
 winapi = { version = "^0.3", features = ["profileapi"] }
 
 [dev-dependencies]
+average = "^0.10"
 criterion = "^0.3"
 clocksource = "^0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -436,8 +436,8 @@ mod tests {
         // of code, etc.
         let clock = Clock::new();
         let sleep_period = Duration::from_millis(100);
-        let lower = sleep_period.as_secs_f64() * 0.9;
-        let upper = sleep_period.as_secs_f64() * 1.1;
+        let lower = duration_to_f64(sleep_period) * 0.9;
+        let upper = duration_to_f64(sleep_period) * 1.1;
 
         let loop_iters = 50;
         let mut deltas = Vec::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,7 +375,7 @@ impl Default for Clock {
 
 #[cfg(test)]
 mod tests {
-    use super::Clock;
+    use super::{duration_to_f64, Clock};
     use average::Variance;
     use std::thread;
     use std::time::Duration;
@@ -448,9 +448,14 @@ mod tests {
             deltas.push(end - start);
         }
 
-        let result: Variance = deltas.into_iter().map(|d| d.as_secs_f64()).collect();
+        let result: Variance = deltas.into_iter().map(duration_to_f64).collect();
 
         assert!(result.mean() >= lower && result.mean() <= upper);
         assert!(result.sample_variance() < result.mean() * 0.1);
     }
+}
+
+#[allow(dead_code)]
+fn duration_to_f64(d: Duration) -> f64 {
+    (d.as_secs() as f64) + (d.subsec_nanos() as f64) / (1_000_000_000 as f64)
 }


### PR DESCRIPTION
Apply the same `cfg` attributes to `Clock::new` as we use to determine if we have access to RDTSC, ensuring that calibration is triggered correctly.

We've also backported entries into the changelog.

Fixes #13.