### PR TITLE
Quanta overhaul: calibration speed, accuracy, and more

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ harness = false
 metrics = ["metrics-core"]
 
 [dependencies]
+once_cell = "^1.4"
 metrics-core = { version = "^0.5", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/benches/timing.rs
+++ b/benches/timing.rs
@@ -23,7 +23,7 @@ fn time_clocksource_counter_scaled(b: &mut Bencher) {
 }
 
 fn time_quanta_now(b: &mut Bencher) {
-    let clock = Clock::new();
+    let mut clock = Clock::new();
     b.iter(|| clock.now())
 }
 
@@ -93,7 +93,7 @@ fn time_quanta_raw_delta(b: &mut Bencher) {
 }
 
 fn time_quanta_now_delta(b: &mut Bencher) {
-    let clock = Clock::new();
+    let mut clock = Clock::new();
     b.iter(|| {
         let start = clock.now();
         let end = clock.now();

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -1,7 +1,5 @@
 use crate::ClockSource;
 
-#[cfg(all(target_arch = "x86", target_feature = "sse2"))]
-use std::arch::x86::{__rdtscp, _mm_lfence, _rdtsc};
 #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
 use std::arch::x86_64::{__rdtscp, _mm_lfence, _rdtsc};
 
@@ -15,10 +13,7 @@ impl Counter {
     }
 }
 
-#[cfg(all(
-    any(target_arch = "x86", target_arch = "x86_64"),
-    target_feature = "sse2"
-))]
+#[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
 impl ClockSource for Counter {
     fn now(&self) -> u64 {
         unsafe {
@@ -46,10 +41,7 @@ impl ClockSource for Counter {
     }
 }
 
-#[cfg(not(all(
-    any(target_arch = "x86", target_arch = "x86_64"),
-    target_feature = "sse2"
-)))]
+#[cfg(not(all(target_arch = "x86_64", target_feature = "sse2")))]
 impl ClockSource for Counter {
     fn now(&self) -> u64 {
         panic!("can't use counter without TSC support");

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -10,9 +10,9 @@ use std::time::Duration;
 ///
 /// Represents a time measurement that has been taken by [`Clock`](crate::Clock) and scaled to reference time.
 ///
-/// Unlike the stdlib `Instant`, this type has a meaningful difference:
-/// - It is intended to be opaque, but the internal value _can_ be accessed.  There are no
-/// guarantees here and depending on this value directly is caveat emptor.
+/// Unlike the stdlib `Instant`, this type has a meaningful difference: it is intended to be opaque, but the
+/// internal value _can_ be accessed.  There are no guarantees here and depending on this value directly is
+/// proceeding at your own risk. ⚠️
 ///
 /// An `Instant` is 8 bytes.
 #[derive(Clone, Copy, PartialEq, Eq)]

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -8,25 +8,17 @@ use std::time::Duration;
 
 /// A point-in-time wall-clock measurement.
 ///
-/// Represents a time measurement that has been taken by [`Clock`](crate::Clock) and scaled to wall-clock time.
+/// Represents a time measurement that has been taken by [`Clock`](crate::Clock) and scaled to reference time.
 ///
-/// Unlike the stdlib `Instant`, this type has two meaningful differences:
-/// - It provides no guarantees around monotonicity whatsoever, beyond any guarantees provided by
-/// `Clock` itself.
-/// - It is intended to be opaque, but the internal value can be accessed.  There are no guarantees
-/// on the internal value timebase, or other factors, remaining stable over time and this
-/// convenience is only intended for comparisons of `Instant`s provided by the same exact `Clock`
-/// instance.
+/// Unlike the stdlib `Instant`, this type has a meaningful difference:
+/// - It is intended to be opaque, but the internal value _can_ be accessed.  There are no
+/// guarantees here and depending on this value directly is caveat emptor.
 ///
 /// An `Instant` is 8 bytes.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct Instant(pub(crate) u64);
 
 impl Instant {
-    pub(crate) fn new(inner: u64) -> Self {
-        Instant(inner)
-    }
-
     /// Returns the amount of time elapsed from another instant to this one.
     ///
     /// # Panics
@@ -40,7 +32,7 @@ impl Instant {
     /// use std::time::Duration;
     /// use std::thread::sleep;
     ///
-    /// let clock = Clock::new();
+    /// let mut clock = Clock::new();
     /// let now = clock.now();
     /// sleep(Duration::new(1, 0));
     /// let new_now = clock.now();
@@ -63,7 +55,7 @@ impl Instant {
     /// use std::time::Duration;
     /// use std::thread::sleep;
     ///
-    /// let clock = Clock::new();
+    /// let mut clock = Clock::new();
     /// let now = clock.now();
     /// sleep(Duration::new(1, 0));
     /// let new_now = clock.now();
@@ -84,7 +76,7 @@ impl Instant {
     /// use std::time::Duration;
     /// use std::thread::sleep;
     ///
-    /// let clock = Clock::new();
+    /// let mut clock = Clock::new();
     /// let now = clock.now();
     /// sleep(Duration::new(1, 0));
     /// let new_now = clock.now();

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -10,8 +10,8 @@ use std::{
 
 /// Type which can be converted into a nanosecond representation.
 ///
-/// This allows users of [`Mock`] to increment/decrement the time both with raw integer values and
-/// the more convenient [`Duration`] type.
+/// This allows users of [`Mock`] to increment/decrement the time both with raw
+/// integer values and the more convenient [`Duration`] type.
 pub trait IntoNanoseconds {
     fn into_nanos(self) -> u64;
 }
@@ -29,6 +29,14 @@ impl IntoNanoseconds for Duration {
 }
 
 /// Controllable time source for use in tests.
+///
+/// A mocked clock allows the caller to adjust the given time backwards and forwards by whatever
+/// amount they choose.  While [`Clock`](crate::Clock) promises monotonic values for normal readings,
+/// when running in mocked mode, these guarantees do not apply: the given `Clock`/`Mock` pair are
+/// directly coupled.
+///
+/// This can be useful for not only testing code that depends on the passage of time, but also for
+/// testing that code can handle large shifts in time.
 #[derive(Debug, Clone)]
 pub struct Mock {
     offset: Arc<AtomicU64>,
@@ -51,6 +59,11 @@ impl Mock {
     pub fn decrement<N: IntoNanoseconds>(&self, amount: N) {
         self.offset
             .fetch_sub(amount.into_nanos(), Ordering::Release);
+    }
+
+    /// Gets the current value of this `Mock`.
+    pub fn value(&self) -> u64 {
+        self.offset.load(Ordering::Acquire)
     }
 }
 

--- a/src/monotonic.rs
+++ b/src/monotonic.rs
@@ -3,15 +3,6 @@ use crate::ClockSource;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 use mach::mach_time::{mach_continuous_time, mach_timebase_info};
 
-#[cfg(all(
-    not(target_os = "macos"),
-    not(target_os = "ios"),
-    not(target_os = "windows")
-))]
-#[derive(Debug, Clone)]
-pub struct Monotonic;
-
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "windows"))]
 #[derive(Debug, Clone)]
 pub struct Monotonic {
     factor: u64,
@@ -24,7 +15,7 @@ pub struct Monotonic {
 ))]
 impl Monotonic {
     pub fn new() -> Monotonic {
-        Monotonic {}
+        Monotonic { factor: 0 }
     }
 }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,0 +1,59 @@
+/// Estimates the arithmetic mean (and the error) for a set of samples.
+///
+/// This type is written and maintained internally as it is trivial to implement and doesn't
+/// warrant a separate dependency.  As well, we add some features like exposing the sample count,
+/// calculating the mean + error value, etc, that existing crates don't do.
+///
+/// Based on Welford's algorithm: computes the mean incrementally, with constant time and
+/// space complexity.
+///
+/// https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm
+#[derive(Default)]
+pub(crate) struct Variance {
+    mean: f64,
+    n: u64,
+    sum_sq: f64,
+}
+
+impl Variance {
+    #[inline]
+    pub fn add(&mut self, sample: f64) {
+        self.n += 1;
+        let n_f = self.n as f64;
+        let delta = (sample - self.mean) / self.n as f64;
+        self.mean += delta;
+        self.sum_sq += delta * delta * n_f * (n_f - 1.0);
+    }
+
+    #[inline]
+    pub fn mean(&self) -> f64 {
+        self.mean
+    }
+
+    #[inline]
+    pub fn mean_error(&self) -> f64 {
+        if self.n < 2 {
+            return 0.0;
+        }
+
+        let n_f = self.n as f64;
+        ((self.sum_sq / (n_f - 1.0)) / n_f).sqrt()
+    }
+
+    #[inline]
+    pub fn mean_with_error(&self) -> u64 {
+        let mean = self.mean.abs();
+        let total = mean + self.mean_error().abs();
+        total as u64
+    }
+
+    #[inline]
+    pub fn has_significant_result(&self) -> bool {
+        self.n >= 2
+    }
+
+    #[inline]
+    pub fn samples(&self) -> u64 {
+        self.n
+    }
+}

--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -1,6 +1,6 @@
 use crate::Clock;
 use std::{
-    io,
+    fmt, io,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -9,36 +9,87 @@ use std::{
     time::Duration,
 };
 
-/// Builder for creating an upkeep task.
+static GLOBAL_UPKEEP_RUNNING: AtomicBool = AtomicBool::new(false);
+
+/// Ultra-low-overhead access to slightly-delayed time.
+///
+/// In some applications, there can be a need to check the current time very often, so much so that
+/// the overhead of checking the time can begin to eat up measurable overhead. For some of these
+/// cases, the time may need to be accessed often but does not necessarily need to be incredibly
+/// accurate: one millisecond granularity could be entirely acceptable.
+///
+/// For these cases, we provide a slightly-delayed version of the time to callers via
+/// [`Clock::recent`], which is updated by a background upkeep thread.  That thread is configured
+/// and spanwed via [`Upkeep`].
+///
+/// [`Upkeep`] can construct a new clock (or be passed an existing clock to use), and given an
+/// update interval, and it will faithfully attempt to update the global recent time on the
+/// specified interval.  There is a trade-off to be struck in terms of how often the time is
+/// updated versus the required accuracy.  Checking the time and updating the global reference is
+/// itself not zero-cost, and so care must be taken to analyze the number of readers in order to
+/// ensure that, given a particular update interval, the upkeep thread is saving more CPU time than
+/// would be spent otherwise by directly querying the current time.
+///
+/// The recent time is read and written atomically.  It is global to an application, so if another
+/// codepath creates the upkeep thread, the interval chosen by that instantiation will be the one
+/// that all callers of [`Clock::recent`] end up using.
+///
+/// Multiple upkeep threads cannot exist at the same time.  A new upkeep thread can be started if
+/// the old one is dropped and returns.
+///
+/// In terms of performance, reading the recent time can be up to two to three times as fast as
+/// reading the current time in the optimized case of using the Time Stamp Counter source.  In
+/// practice, while a caller might expect to take 12-14ns to read the TSC and scale it to reference
+/// time, the recent time can be read in 4-5ns, with no reference scale conversion required.
 #[derive(Debug)]
-pub struct Builder {
+pub struct Upkeep {
     interval: Duration,
     clock: Clock,
 }
 
-/// Handle to a running upkeep task.
+/// Handle to a running upkeep thread.
 ///
-/// If a handle is dropped, the background upkeep thread it belongs to is stopped, which will stop
-/// updating the recent time.
+/// If a handle is dropped, the upkeep thread will be stopped, and the recent time will cease to
+/// update.  The upkeep thread can be started again to resume updating the recent time.
 #[derive(Debug)]
 pub struct Handle {
     done: Arc<AtomicBool>,
     handle: Option<JoinHandle<()>>,
 }
 
-impl Builder {
-    /// Creates a new [`Builder`].
+/// Errors thrown during the creation/spawning of the upkeep thread.
+#[derive(Debug)]
+pub enum Error {
+    /// An upkeep thread is already running in this process.
+    UpkeepRunning,
+    /// An error occurred when trying to spawn the upkeep thread.
+    FailedToSpawnUpkeepThread(io::Error),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::UpkeepRunning => write!(f, "upkeep thread already running"),
+            Error::FailedToSpawnUpkeepThread(e) => {
+                write!(f, "failed to spanw upkeep thread: {}", e)
+            }
+        }
+    }
+}
+
+impl Upkeep {
+    /// Creates a new [`Upkeep`].
     ///
     /// This creates a new internal clock for acquiring the current time.  If you have an existing
     /// [`Clock`] that is already calibrated, it is slightly faster to clone it and construct the
-    /// builder with [`new_with_clock`](Builder::new_with_clock) to avoid recalibrating.
-    pub fn new(interval: Duration) -> Builder {
+    /// builder with [`new_with_clock`](Upkeep::new_with_clock) to avoid recalibrating.
+    pub fn new(interval: Duration) -> Upkeep {
         Self::new_with_clock(interval, Clock::new())
     }
 
-    /// Creates a new [`Builder`] with the specified [`Clock`] instance.
-    pub fn new_with_clock(interval: Duration, clock: Clock) -> Builder {
-        Builder { interval, clock }
+    /// Creates a new [`Upkeep`] with the specified [`Clock`] instance.
+    pub fn new_with_clock(interval: Duration, clock: Clock) -> Upkeep {
+        Upkeep { interval, clock }
     }
 
     /// Start the upkeep thread, periodically updating the global coarse time.
@@ -46,9 +97,14 @@ impl Builder {
     /// If the return value is [`Ok(handle)`], then the thread was spawned successfully and can be
     /// stopped by dropping the returned handle.  Otherwise, [`Err`] contains the error that was
     /// returned when trying to spawn the thread.
-    pub fn start(self) -> Result<Handle, io::Error> {
+    pub fn start(self) -> Result<Handle, Error> {
+        // If another upkeep thread is running, inform the caller.
+        if !GLOBAL_UPKEEP_RUNNING.compare_and_swap(false, true, Ordering::SeqCst) {
+            return Err(Error::UpkeepRunning);
+        }
+
         let interval = self.interval;
-        let clock = self.clock;
+        let mut clock = self.clock;
 
         let done = Arc::new(AtomicBool::new(false));
         let their_done = done.clone();
@@ -62,7 +118,10 @@ impl Builder {
 
                     thread::sleep(interval);
                 }
-            })?;
+
+                GLOBAL_UPKEEP_RUNNING.store(false, Ordering::SeqCst);
+            })
+            .map_err(Error::FailedToSpawnUpkeepThread)?;
 
         Ok(Handle {
             done,


### PR DESCRIPTION
This PR is the sum of many different changes all centered around: how do we make `quanta` safer and faster to use?

Safety in Rust almost always carries the meaning of _memory_ safety, but in this case, we're talking about the safety of the data itself: whether it can be relied on, what invariants are provided by the crate to users, etc.

The changes are vast so we'll list them out below in general sections.

### Data safety / monotonicity

Simply put, `quanta` previously had no check to ensure that a second measurement from the same `Clock` didn't end up coming _before_ the previous measurement.  This was/is a small possibility because of the nature of the Time Stamp Counter -- which could be fiddled with at runtime by the OS/hypervisor/etc -- and so the right thing to do is check for this condition and prevent it.

With this PR, `Clock::now` will not return a non-monotonic measurement (but it may return the _last_ measurement, so a delta of zero, but never a negative delta) and similarly. for `Clock::delta`, we'll never allow a negative delta.

All methods that return raw values -- `raw`, `start`, and `end` -- have no monotonicity guarantees themselves.  If a user wants to use `Clock::scaled`, they're assuming the (small, but potential) risk of getting a non-monotonic conversion, but `Clock::delta` can still protect them.

### Data correctness / calibration

`quanta` has always run a calibration loop as part of creating a new `Clock`.  This calibration loop traditionally spun for one second before computing the result and moving on, which I didn't believe was high enough to originally warrant change.  Catching a glimpse into how `quanta` is used in the wild, it's clear that people are not OK with `Clock::new` taking a whole second, inexplicably.  We can do better.

Building off the work of the Linux kernel, we've redesigned the calibration loop such that it will do its work incrementally, terminating the loop if it believes it has a stable calibration.  It will also set a deadline for itself which is much shorter than the previous deadline: 200ms vs 1 second.  In practice, most calibration loops will finish in milliseconds, or tens of milliseconds.  Given that computers are noisy, however, I've seen it also hit the deadline in testing: both cases still had a solid calibration. :)

Our calibration correctness/accuracy is computed: we do small chunks of work, adjust our overall reference/source ratios, and then take a measurement from each, seeing how far they diverge.  Once this value (the mean, as well as the error) is suitably low -- we aim for 10ns or less divergence -- then we can be confident we're done.

A side note: a person may look at "10ns or less" and think: but isn't `quanta` supposed to give me nanosecond resolution?  Will all my measurements be limited to 10ns resolution now? Nope!  This is simply the difference between the reference and source clocks, so while the reference and source clock may be 10ns out of sync, nanosecond resolution is still present.

This is also a fun rabbit hole to go down, because ultimately, these clock sources are all ticking at different rates, with different underlying clocks, some physical, some virtual, and it's quite the song and dance if you really wanted them all synced to each other.  Even the latency of the methods themselves means you're always reading an old value!

We've punted on doing any sort of reading of the TSC frequency from the CPU directly because I don't have a good way to test it, and calibration should still be very very accurate.

### Calibration re-use

Callers previously had no way to reuse a calibration, which means redoing the calibration work needlessly.

`Clock::new` will now use a shared calibration -- guarded by a `std::sync::Once`-based cell -- in order. to speed up creating new clocks and to avoid needing to expose the calibration itself and force callers to pass it around.  Cloning an existing `Clock` will still work correctly, using the same calibration.

Alright... that's a lot in one go, but suffice to say, there's a lot of changes here, and we're still working through the code itself, but will have to spend a good chunk of time ensuring that the documentation reflects the new behavior and features, as well as writing tests to cover more of these corner cases.

Ultimately, while `quanta` may have been created with the mindset of "fast, fast, fast!", what we really owe of users is "fast, fast, fast _and_ correct!".

Fixes #15.
Fixes #16.
Fixes #17.