### PR TITLE
[0.3] Add atomic_shim to support platforms where 64-bit atomics are not available

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,12 @@ tsc = []
 libc = "0.2.50"
 atomic-shim = "0.1.0"
 
+[target.'cfg(target_arch = "mips")'.dependencies]
+ctor = "0.1.15"
+
+[target.'cfg(target_arch = "powerpc")'.dependencies]
+ctor = "0.1.15"
+
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.6", features = ["profileapi"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ tsc = []
 
 [dependencies]
 libc = "0.2.50"
+atomic-shim = "0.1.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.6", features = ["profileapi"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,9 +48,10 @@
 #![cfg_attr(feature = "tsc", feature(asm))]
 
 use std::sync::{
-    atomic::{AtomicU64, Ordering},
+    atomic::Ordering,
     Arc,
 };
+use atomic_shim::AtomicU64;
 
 mod monotonic;
 use self::monotonic::Monotonic;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,18 @@ pub use self::mock::{IntoNanoseconds, Mock};
 mod upkeep;
 pub use self::upkeep::{Builder, Handle};
 
+#[cfg(any(target_arch = "mips", target_arch = "powerpc"))]
+mod atomic_compat {
+    use super::AtomicU64;
+    use ctor::ctor;
+    
+    #[ctor]
+    pub static GLOBAL_RECENT: AtomicU64 = AtomicU64::new(0);
+}
+#[cfg(any(target_arch = "mips", target_arch = "powerpc"))]
+use self::atomic_compat::GLOBAL_RECENT;
+
+#[cfg(not(any(target_arch = "mips", target_arch = "powerpc")))]
 static GLOBAL_RECENT: AtomicU64 = AtomicU64::new(0);
 
 type Reference = Monotonic;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -1,10 +1,8 @@
 #![allow(dead_code)]
 use crate::ClockSource;
+use atomic_shim::AtomicU64;
 use std::{
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
+    sync::{atomic::Ordering, Arc},
     time::Duration,
 };
 


### PR DESCRIPTION
Backport of PR https://github.com/metrics-rs/quanta/pull/23 to `0.3.1`
Should I bump the version in `Cargo.toml` to `0.3.2` ?