### PR TITLE
Fix error with upkeep protection logic.

### DIFF
--- a/benches/timing.rs
+++ b/benches/timing.rs
@@ -1,4 +1,3 @@
-use clocksource::Clocksource;
 use criterion::{criterion_group, criterion_main, Bencher, Criterion};
 use quanta::Clock;
 use std::time::Instant;

--- a/release.toml
+++ b/release.toml
@@ -1,3 +1,4 @@
+no-dev-version = true
 sign-commit = true
 sign-tag = true
 pre-release-replacements = [


### PR DESCRIPTION
In `0.6.0`, we added a check to ensure that an application could not start more than one global upkeep thread at a time.  The implementation of this check had a logic error where it would say that an upkeep thread was already spawned, no matter what.  This PR fixes that bug.

We now have a test that exercises the behavior.

Fixes #28.