### PR TITLE
Add check for RDTSCP support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quanta"
-version = "0.6.5"
+version = "0.6.6-alpha.1"
 authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
 edition = "2018"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -549,8 +549,8 @@ fn has_constant_or_better_tsc() -> bool {
         _ => return false,
     }
 
-    // We check CPUID for nonstop/invariant TSC as our fallback. (CPUID EAX=0x8000_0007, bit 8)
-    read_cpuid_nonstop_tsc()
+    // Check to make sure we have nonstop TSC + RDTSCP support.
+    read_cpuid_nonstop_tsc() && read_cpuid_rdtscp_support()
 }
 
 #[allow(dead_code)]
@@ -573,6 +573,14 @@ fn read_cpuid_nonstop_tsc() -> bool {
     cpuid
         .get_extended_function_info()
         .map_or(false, |efi| efi.has_invariant_tsc())
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn read_cpuid_rdtscp_support() -> bool {
+    let cpuid = CpuId::new();
+    cpuid
+        .get_extended_function_info()
+        .map_or(false, |efi| efi.has_rdtscp())
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]


### PR DESCRIPTION
Currently, we assume that any x86/x86-64 target with SSE2 support with have RDTSCP support, which has been proven, unfortunately, false: https://discordapp.com/channels/500028886025895936/500336333500448798/758031350409199627

I'm still not sure _why_ the system didn't have RDTSCP support even though it had nonstop TSC, but we can avoid the very ugly SIGILL by simply checking at runtime if the host also has RDTSC support via CPUID.

The `Counter` code will be compiled with `rdtsc`, but it won't be used because we'll never hit the branch that tells us to do so.