### PR TITLE
clock: change `Clock::now` to take an `&self` receiver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust_version: ['1.36.0', 'stable', 'nightly']
+        rust_version: ['1.45.0', 'stable', 'nightly']
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
     - uses: actions/checkout@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+### Changed
+- MSRV bumped to 1.45.0.
+- `Clock::now` takes `&self` instead of `&mut self`.
 
 ## [0.6.5] - 2020-09-16
 ### Changed

--- a/benches/timing.rs
+++ b/benches/timing.rs
@@ -7,7 +7,7 @@ fn time_instant_now(b: &mut Bencher) {
 }
 
 fn time_quanta_now(b: &mut Bencher) {
-    let mut clock = Clock::new();
+    let clock = Clock::new();
     b.iter(|| clock.now())
 }
 
@@ -59,7 +59,7 @@ fn time_quanta_raw_delta(b: &mut Bencher) {
 }
 
 fn time_quanta_now_delta(b: &mut Bencher) {
-    let mut clock = Clock::new();
+    let clock = Clock::new();
     b.iter(|| {
         let start = clock.now();
         let end = clock.now();

--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -104,7 +104,7 @@ impl Upkeep {
         }
 
         let interval = self.interval;
-        let mut clock = self.clock;
+        let clock = self.clock;
 
         let done = Arc::new(AtomicBool::new(false));
         let their_done = done.clone();


### PR DESCRIPTION
Currently, `Clock::now` takes an `&mut self` receiver. This is because
the last `now` value stored in the clock must be updated when using the
`Counter` clock type. However, since the `now` value is a single `u64`,
it's possible to implement this using `AtomicU64::fetch_max` instead,
allowing `Clock::now` to take a shared reference rather than a mutable
reference.

This requires changing `ClockType` to use a manual `Clone` impl, as
`atomic_shim::AtomicU64` doesn't implement `Clone`.

This does have one potential downside, which is that `atomic_shim` may
fall back to locking on platforms _without_ native 64-bit atomics. If
that's a serious issue, we might prefer not to make this change.
However, this lets targets with 64-bit atomics avoid a layer of locking
that would otherwise *always* be necessary if `Clock::now` is used
without a mutable reference to the clock available.

Since this changes a public method signature, this should be considered
a breaking change.

Let me know what you think!

Signed-off-by: Eliza Weisman <eliza@buoyant.io>