### PR TITLE
Enhancements to Instant and mocking.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         rust_version: ['1.45.0', 'stable', 'nightly']
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Install Rust ${{ matrix.rust_version }}
       uses: actions-rs/toolchain@v1
       with:
@@ -42,14 +42,15 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Install Rust Stable
       uses: actions-rs/toolchain@v1
       with:
           toolchain: 'stable'
           override: true
     - name: Run Benchmarks
-      run: cargo bench -- --output-format bencher | tee output.txt
+      run: cargo bench -- --output-format bencher | tee ../output.txt
+      working-directory: benches
     - name: Process benchmark results
       uses: rhysd/github-action-benchmark@v1
       with:
@@ -60,4 +61,4 @@ jobs:
           comment-on-alert: true
           fail-on-alert: true
           alert-comment-cc-users: '@tobz'
-          auto-push: ${{ github.ref == 'refs/heads/main' }}
+          auto-push: ${{ github.ref == 'refs/heads/master' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,14 +49,14 @@ jobs:
           toolchain: 'stable'
           override: true
     - name: Run Benchmarks
-      run: cargo bench -- --output-format bencher | tee ../output.txt
-      working-directory: benches
+      run: cargo bench -- --output-format bencher | tee output.txt
     - name: Process benchmark results
       uses: rhysd/github-action-benchmark@v1
       with:
           tool: 'cargo'
           output-file-path: output.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment-always: true
           alert-threshold: '10%'
           comment-on-alert: true
           fail-on-alert: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,4 +49,15 @@ jobs:
           toolchain: 'stable'
           override: true
     - name: Run Benchmarks
-      run: cargo bench
+      run: cargo bench -- --output-format bencher | tee output.txt
+    - name: Process benchmark results
+      uses: rhysd/github-action-benchmark@v1
+      with:
+          tool: 'cargo'
+          output-file-path: output.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          alert-threshold: '10%'
+          comment-on-alert: true
+          fail-on-alert: true
+          alert-comment-cc-users: '@tobz'
+          auto-push: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           toolchain: ${{ matrix.rust_version }}
           override: true
     - name: Run Tests
-      run: cargo test
+      run: cargo test --all-features -- --test-threads=1
   bench:
     name: Bench ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - MSRV bumped to 1.45.0.
 - `Clock::now` takes `&self` instead of `&mut self`.
+- Fixed a bug where a failure to spawn the upkeep thread would not allow subsequent attempts to
+  spawn the upkeep thread to proceed.
+
+### Added
+- New methods --`Instant::now` and `Instant::recent` for getting the current and recent time,
+  respectively.
+- New free function `quanta::with_clock` for setting an override on the current thread that affects
+  calls made to `Instant::now` and `Instant::recent`.
+- New free function `quanta::set_recent` to allow customization of how global recent time is updated.
 
 ## [0.6.5] - 2020-09-16
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ prost = ["prost-types"]
 [dependencies]
 once_cell = "1.4"
 metrics-core = { version = "0.5", optional = true }
-prost-types = { version = "0.6", optional = true }
+prost-types = { version = "0.7", optional = true }
 atomic-shim = "0.1.0"
 
 [target.'cfg(target_arch = "x86")'.dependencies]
@@ -40,10 +40,10 @@ raw-cpuid = "8.1"
 raw-cpuid = "8.1"
 
 [target.'cfg(target_arch = "mips")'.dependencies]
-ctor = "0.1.15"
+ctor = "0.1"
 
 [target.'cfg(target_arch = "powerpc")'.dependencies]
-ctor = "0.1.15"
+ctor = "0.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ keywords = ["rdtsc", "timing", "nanosecond"]
 [package.metadata.docs.rs]
 all-features = true
 
+[lib]
+bench = false
+
 [[bench]]
 name = "timing"
 harness = false

--- a/benches/timing.rs
+++ b/benches/timing.rs
@@ -1,14 +1,19 @@
 use criterion::{criterion_group, criterion_main, Bencher, Criterion};
-use quanta::Clock;
-use std::time::Instant;
+use quanta::{Clock, Instant as QuantaInstant};
+use std::time::Instant as StdInstant;
 
 fn time_instant_now(b: &mut Bencher) {
-    b.iter(|| Instant::now())
+    b.iter(|| StdInstant::now())
 }
 
 fn time_quanta_now(b: &mut Bencher) {
     let clock = Clock::new();
     b.iter(|| clock.now())
+}
+
+fn time_quanta_instant_now(b: &mut Bencher) {
+    let _ = QuantaInstant::now();
+    b.iter(|| QuantaInstant::now());
 }
 
 fn time_quanta_raw(b: &mut Bencher) {
@@ -43,8 +48,8 @@ fn time_quanta_end_scaled(b: &mut Bencher) {
 
 fn time_instant_delta(b: &mut Bencher) {
     b.iter(|| {
-        let start = Instant::now();
-        let d = Instant::now() - start;
+        let start = StdInstant::now();
+        let d = StdInstant::now() - start;
         (d.as_secs() * 1_000_000_000) + u64::from(d.subsec_nanos())
     })
 }
@@ -81,6 +86,11 @@ fn time_quanta_recent(b: &mut Bencher) {
     b.iter(|| clock.recent())
 }
 
+fn time_quanta_instant_recent(b: &mut Bencher) {
+    quanta::set_recent(QuantaInstant::now());
+    b.iter(|| QuantaInstant::recent());
+}
+
 fn benchmark(c: &mut Criterion) {
     let mut std_group = c.benchmark_group("stdlib");
     std_group.bench_function("instant now", time_instant_now);
@@ -90,6 +100,7 @@ fn benchmark(c: &mut Criterion) {
     let mut q_group = c.benchmark_group("quanta");
     q_group.bench_function("quanta now", time_quanta_now);
     q_group.bench_function("quanta now delta", time_quanta_now_delta);
+    q_group.bench_function("quanta instant now", time_quanta_instant_now);
     q_group.bench_function("quanta raw", time_quanta_raw);
     q_group.bench_function("quanta raw scaled", time_quanta_raw_scaled);
     q_group.bench_function("quanta raw delta", time_quanta_raw_delta);
@@ -99,6 +110,7 @@ fn benchmark(c: &mut Criterion) {
     q_group.bench_function("quanta end scaled", time_quanta_end_scaled);
     q_group.bench_function("quanta start/end delta", time_quanta_start_end_delta);
     q_group.bench_function("quanta recent", time_quanta_recent);
+    q_group.bench_function("quanta instant recent", time_quanta_instant_recent);
     q_group.finish();
 }
 

--- a/benches/timing.rs
+++ b/benches/timing.rs
@@ -93,24 +93,24 @@ fn time_quanta_instant_recent(b: &mut Bencher) {
 
 fn benchmark(c: &mut Criterion) {
     let mut std_group = c.benchmark_group("stdlib");
-    std_group.bench_function("instant now", time_instant_now);
-    std_group.bench_function("instant delta", time_instant_delta);
+    std_group.bench_function("instant_now", time_instant_now);
+    std_group.bench_function("instant_delta", time_instant_delta);
     std_group.finish();
 
     let mut q_group = c.benchmark_group("quanta");
-    q_group.bench_function("quanta now", time_quanta_now);
-    q_group.bench_function("quanta now delta", time_quanta_now_delta);
-    q_group.bench_function("quanta instant now", time_quanta_instant_now);
-    q_group.bench_function("quanta raw", time_quanta_raw);
-    q_group.bench_function("quanta raw scaled", time_quanta_raw_scaled);
-    q_group.bench_function("quanta raw delta", time_quanta_raw_delta);
-    q_group.bench_function("quanta start", time_quanta_start);
-    q_group.bench_function("quanta start scaled", time_quanta_start_scaled);
-    q_group.bench_function("quanta end", time_quanta_end);
-    q_group.bench_function("quanta end scaled", time_quanta_end_scaled);
-    q_group.bench_function("quanta start/end delta", time_quanta_start_end_delta);
-    q_group.bench_function("quanta recent", time_quanta_recent);
-    q_group.bench_function("quanta instant recent", time_quanta_instant_recent);
+    q_group.bench_function("quanta_now", time_quanta_now);
+    q_group.bench_function("quanta_now_delta", time_quanta_now_delta);
+    q_group.bench_function("quanta_instant_now", time_quanta_instant_now);
+    q_group.bench_function("quanta_raw", time_quanta_raw);
+    q_group.bench_function("quanta_raw_scaled", time_quanta_raw_scaled);
+    q_group.bench_function("quanta_raw_delta", time_quanta_raw_delta);
+    q_group.bench_function("quanta_start", time_quanta_start);
+    q_group.bench_function("quanta_start_scaled", time_quanta_start_scaled);
+    q_group.bench_function("quanta_end", time_quanta_end);
+    q_group.bench_function("quanta_end_scaled", time_quanta_end_scaled);
+    q_group.bench_function("quanta_start/end_delta", time_quanta_start_end_delta);
+    q_group.bench_function("quanta_recent", time_quanta_recent);
+    q_group.bench_function("quanta_instant_recent", time_quanta_instant_recent);
     q_group.finish();
 }
 

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -1,7 +1,5 @@
-use crate::ClockSource;
-
 #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
-use std::arch::x86_64::{__rdtscp, _mm_lfence, _rdtsc};
+use core::arch::x86_64::{__rdtscp, _mm_lfence, _rdtsc};
 
 #[derive(Debug, Clone, Default)]
 pub struct Counter;
@@ -14,15 +12,15 @@ impl Counter {
 }
 
 #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
-impl ClockSource for Counter {
-    fn now(&self) -> u64 {
+impl Counter {
+    pub fn now(&self) -> u64 {
         unsafe {
             _mm_lfence();
             _rdtsc()
         }
     }
 
-    fn start(&self) -> u64 {
+    pub fn start(&self) -> u64 {
         unsafe {
             _mm_lfence();
             let result = _rdtsc();
@@ -31,7 +29,7 @@ impl ClockSource for Counter {
         }
     }
 
-    fn end(&self) -> u64 {
+    pub fn end(&self) -> u64 {
         let mut _aux: u32 = 0;
         unsafe {
             let result = __rdtscp(&mut _aux as *mut _);
@@ -42,7 +40,7 @@ impl ClockSource for Counter {
 }
 
 #[cfg(not(all(target_arch = "x86_64", target_feature = "sse2")))]
-impl ClockSource for Counter {
+impl Counter {
     fn now(&self) -> u64 {
         panic!("can't use counter without TSC support");
     }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code)]
-use crate::ClockSource;
 use atomic_shim::AtomicU64;
 use std::{
     sync::{atomic::Ordering, Arc},
@@ -62,19 +61,5 @@ impl Mock {
     /// Gets the current value of this `Mock`.
     pub fn value(&self) -> u64 {
         self.offset.load(Ordering::Acquire)
-    }
-}
-
-impl ClockSource for Mock {
-    fn now(&self) -> u64 {
-        self.offset.load(Ordering::Acquire)
-    }
-
-    fn start(&self) -> u64 {
-        self.now()
-    }
-
-    fn end(&self) -> u64 {
-        self.now()
     }
 }

--- a/src/monotonic.rs
+++ b/src/monotonic.rs
@@ -1,5 +1,3 @@
-use crate::ClockSource;
-
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 use mach::mach_time::{mach_continuous_time, mach_timebase_info};
 
@@ -24,8 +22,8 @@ impl Monotonic {
     not(target_os = "ios"),
     not(target_os = "windows")
 ))]
-impl ClockSource for Monotonic {
-    fn now(&self) -> u64 {
+impl Monotonic {
+    pub fn now(&self) -> u64 {
         let mut ts = libc::timespec {
             tv_sec: 0,
             tv_nsec: 0,
@@ -34,14 +32,6 @@ impl ClockSource for Monotonic {
             libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts);
         }
         (ts.tv_sec as u64) * 1_000_000_000 + (ts.tv_nsec as u64)
-    }
-
-    fn start(&self) -> u64 {
-        self.now()
-    }
-
-    fn end(&self) -> u64 {
-        self.now()
     }
 }
 
@@ -68,8 +58,8 @@ impl Monotonic {
 }
 
 #[cfg(target_os = "windows")]
-impl ClockSource for Monotonic {
-    fn now(&self) -> u64 {
+impl Monotonic {
+    pub fn now(&self) -> u64 {
         use std::mem;
         use winapi::um::profileapi;
 
@@ -83,14 +73,6 @@ impl ClockSource for Monotonic {
             *count.QuadPart() as u64
         };
         raw * self.factor
-    }
-
-    fn start(&self) -> u64 {
-        self.now()
-    }
-
-    fn end(&self) -> u64 {
-        self.now()
     }
 }
 
@@ -108,18 +90,10 @@ impl Monotonic {
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
-impl ClockSource for Monotonic {
-    fn now(&self) -> u64 {
+impl Monotonic {
+    pub fn now(&self) -> u64 {
         let raw = unsafe { mach_continuous_time() };
         raw * self.factor
-    }
-
-    fn start(&self) -> u64 {
-        self.now()
-    }
-
-    fn end(&self) -> u64 {
-        self.now()
     }
 }
 


### PR DESCRIPTION
This PR introduces a bunch of changes that work together in concert:
- `Instant::now` and `Instant::recent` have been added
- `with_clock` has been added to make those two functions mockable
- `set_recent` has been added so callers can avoid spawning an entire thread for upkeep (i.e. use an async task instead)