### PR TITLE
realign cfg deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ ctor = "0.1"
 [target.'cfg(target_arch = "powerpc")'.dependencies]
 ctor = "0.1"
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(all(not(target_os = "macos"), not(target_os = "ios"), not(target_os = "windows")))'.dependencies]
 libc = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]


### PR DESCRIPTION
Currently, os targets with valid `libc` access are currently being omitted from the dependency tree with the `[target.'cfg(target_os = "linux")'.dependencies]`annotation. In code, the annotation is `cfg(all(not(target_os = "macos"), not(target_os = "ios"), not(target_os = "windows")))`. This PR sets the `Cargo.toml` configuration to match the in code configuration.

