### PR TITLE
Add support for WASM targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,3 +69,6 @@ wasi = "0.10"
 [dev-dependencies]
 average = "0.12"
 criterion = "0.3"
+
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
+wasm-bindgen-test = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ ctor = "0.1"
 [target.'cfg(target_arch = "powerpc")'.dependencies]
 ctor = "0.1"
 
-[target.'cfg(all(not(target_os = "macos"), not(target_os = "ios"), not(target_os = "windows")))'.dependencies]
+[target.'cfg(all(not(target_os = "macos"), not(target_os = "ios"), not(target_os = "windows"), not(target_arch = "wasm32")))'.dependencies]
 libc = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -59,6 +59,12 @@ mach = "0.3"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["profileapi"] }
+
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+web-sys = { version = "0.3", features = ["Window", "Performance"] }
+
+[target.'cfg(all(target_arch = "wasm32", target_os = "wasi"))'.dependencies]
+wasi = "0.10"
 
 [dev-dependencies]
 average = "0.12"

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -221,6 +221,10 @@ mod tests {
     use std::time::Duration;
 
     #[test]
+    #[cfg_attr(
+        all(target_arch = "wasm32", target_os = "unknown"),
+        ignore = "WASM thread cannot sleep"
+    )]
     fn test_now() {
         let t0 = Instant::now();
         thread::sleep(Duration::from_millis(15));
@@ -235,6 +239,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(
+        all(target_arch = "wasm32", target_os = "unknown"),
+        ignore = "WASM thread cannot sleep"
+    )]
     fn test_recent() {
         // Ensures that the recent global value is zero so that the fallback logic can kick in.
         crate::set_recent(Instant(0));
@@ -258,6 +266,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(
+        all(target_arch = "wasm32", target_os = "unknown"),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
     fn test_mocking() {
         let (clock, mock) = Clock::mock();
         with_clock(&clock, move || {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -646,11 +646,22 @@ fn read_cpuid_family_model() -> u32 {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::{Clock, Monotonic};
     use average::{Merge, Variance};
 
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    mod configure_wasm_tests {
+        // until https://github.com/rustwasm/wasm-bindgen/issues/2571 is resolved
+        // these tests will only run in browsers
+        wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+    }
+
     #[test]
+    #[cfg_attr(
+        all(target_arch = "wasm32", target_os = "unknown"),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
     fn test_mock() {
         let (clock, mock) = Clock::mock();
         assert_eq!(clock.now().as_u64(), 0);
@@ -659,30 +670,50 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(
+        all(target_arch = "wasm32", target_os = "unknown"),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
     fn test_now() {
         let clock = Clock::new();
         assert!(clock.now().as_u64() > 0);
     }
 
     #[test]
+    #[cfg_attr(
+        all(target_arch = "wasm32", target_os = "unknown"),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
     fn test_raw() {
         let clock = Clock::new();
         assert!(clock.raw() > 0);
     }
 
     #[test]
+    #[cfg_attr(
+        all(target_arch = "wasm32", target_os = "unknown"),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
     fn test_start() {
         let clock = Clock::new();
         assert!(clock.start() > 0);
     }
 
     #[test]
+    #[cfg_attr(
+        all(target_arch = "wasm32", target_os = "unknown"),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
     fn test_end() {
         let clock = Clock::new();
         assert!(clock.end() > 0);
     }
 
     #[test]
+    #[cfg_attr(
+        all(target_arch = "wasm32", target_os = "unknown"),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
     fn test_scaled() {
         let clock = Clock::new();
         let raw = clock.raw();
@@ -692,6 +723,10 @@ mod tests {
 
     #[test]
     #[cfg_attr(not(feature = "flaky_tests"), ignore)]
+    #[cfg_attr(
+        all(target_arch = "wasm32", target_os = "unknown"),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
     fn test_reference_source_calibration() {
         let clock = Clock::new();
         let reference = Monotonic::new();
@@ -727,6 +762,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(
+        all(target_arch = "wasm32", target_os = "unknown"),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
     fn test_reference_self_calibration() {
         let reference = Monotonic::new();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,10 +108,21 @@
 //! - raw values may time warp
 //! - measurements from the TSC may drift past or behind the comparable reference clock
 //!
+//! # WASM support
+//!
+//! This library can be built for WASM targets, but in this case the resolution
+//! and accuracy of measurements can be limited by the WASM environment. In
+//! particular, when running on the `wasm32-unknown-unknown` target in browsers,
+//! `quanta` will use [windows.performance.now] as a clock. This mean the
+//! accuracy is limited to milliseconds instead of the usual nanoseconds on
+//! other targets. When running within a WASI environment (target
+//! `wasm32-wasi`), the accuracy of the clock depends on the VM implementation.
+//!
 //! [QueryPerformanceCounter]: https://msdn.microsoft.com/en-us/library/ms644904(v=VS.85).aspx
 //! [mach_continuous_time]: https://developer.apple.com/documentation/kernel/1646199-mach_continuous_time
 //! [clock_gettime]: https://linux.die.net/man/3/clock_gettime
 //! [prost_types_timestamp]: https://docs.rs/prost-types/0.7.0/prost_types/struct.Timestamp.html
+//! [windows.performance.now]: https://developer.mozilla.org/en-US/docs/Web/API/Performance/now
 use atomic_shim::AtomicU64;
 use std::time::Duration;
 use std::{

--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -155,6 +155,7 @@ mod tests {
     use std::time::Duration;
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", ignore)] // WASM is single threaded
     fn test_spawning_second_upkeep() {
         let first = Upkeep::new(Duration::from_millis(250)).start();
         let second = Upkeep::new(Duration::from_millis(250))


### PR DESCRIPTION
This PR adds support for `Monotonic` on both WASM targets: `wasm32-unknown-unknown` (web) and `wasm32-wasi` (wasi). On the web, it uses [window.performance.now()](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now); and on wasi it uses [clock_time_get](https://docs.rs/wasi/0.10.2+wasi-snapshot-preview1/wasi/fn.clock_time_get.html) with a monotonic clock.

I did not ran the tests on these targets, but I'll try to do so in the next few days.