### PR TITLE
Replace `atomic-shim::AtomicU64` with `crossbeam-utils::atomic::AtomicCell<u64>`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,19 +34,13 @@ prost = ["prost-types"]
 [dependencies]
 once_cell = "1.4"
 prost-types = { version = "0.7", optional = true }
-atomic-shim = "0.1.0"
+crossbeam-utils = "0.8"
 
 [target.'cfg(target_arch = "x86")'.dependencies]
 raw-cpuid = "9.0"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 raw-cpuid = "9.0"
-
-[target.'cfg(target_arch = "mips")'.dependencies]
-ctor = "0.1"
-
-[target.'cfg(target_arch = "powerpc")'.dependencies]
-ctor = "0.1"
 
 [target.'cfg(all(not(target_os = "macos"), not(target_os = "ios"), not(target_os = "windows"), not(target_arch = "wasm32")))'.dependencies]
 libc = "0.2"


### PR DESCRIPTION
[`AtomicCell`](https://docs.rs/crossbeam-utils/0.8.5/crossbeam_utils/atomic/struct.AtomicCell.html) seems to be a better option to me, as it supports many more targets (for example [this](https://github.com/crossbeam-rs/crossbeam/blob/master/no_atomic.rs) is the list of targets with no atomic support that work with crossbeam), is maintained and `atomic-shim` relies upon anyway