### PR TITLE
Use `fetch_update` to support mock on 32-bit MIPS and ARMv5TE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,29 @@ jobs:
         override: true
     - name: Run Tests
       run: cargo test --no-default-features --features=prost -- --test-threads=1
+  cross-test:
+    name: Test ${{ matrix.rust_version }}/${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust_version: ['stable']
+        target:
+          - armv5te-unknown-linux-gnueabi
+          - mips-unknown-linux-gnu
+          - mipsel-unknown-linux-gnu
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Rust ${{ matrix.rust_version }}
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.rust_version }}
+        target: ${{ matrix.target }}
+        override: true
+    - uses: actions-rs/cargo@v1
+      with:
+        use-cross: true
+        command: test
+        args: --target ${{ matrix.target }} --no-default-features --features=prost -- --test-threads=1
   bench:
     name: Bench ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust_version: ['1.45.0', 'stable', 'nightly']
+        rust_version: ['1.51.0', 'stable', 'nightly']
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,10 @@ jobs:
       matrix:
         rust_version: ['stable']
         target:
+          - aarch64-unknown-linux-gnu
           - armv5te-unknown-linux-gnueabi
+          - arm-unknown-linux-gnueabi
+          - armv7-unknown-linux-gnueabihf
           - mips-unknown-linux-gnu
           - mipsel-unknown-linux-gnu
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ prost = ["prost-types"]
 
 [dependencies]
 once_cell = "1.4"
-prost-types = { version = "0.7", optional = true }
+prost-types = { version = "0.8", optional = true }
 crossbeam-utils = "0.8.5"
 
 [target.'cfg(target_arch = "x86")'.dependencies]

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -45,12 +45,18 @@ impl Mock {
 
     /// Increments the time by the given amount.
     pub fn increment<N: IntoNanoseconds>(&self, amount: N) {
-        self.offset.fetch_add(amount.into_nanos());
+        let amount = amount.into_nanos();
+        self.offset
+            .fetch_update(|current| Some(current + amount))
+            .unwrap();
     }
 
     /// Decrements the time by the given amount.
     pub fn decrement<N: IntoNanoseconds>(&self, amount: N) {
-        self.offset.fetch_sub(amount.into_nanos());
+        let amount = amount.into_nanos();
+        self.offset
+            .fetch_update(|current| Some(current - amount))
+            .unwrap();
     }
 
     /// Gets the current value of this `Mock`.


### PR DESCRIPTION
Fixes #54.