### PR TITLE
Simplify TSC/RDTSC support check.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+- Simplified how TSC/RDTSC suppoort is detected, which should avoid some situations where it was
+  assumed to be present, but actually was not.
+
 ## [0.9.2] - 2021-08-25
 
 ### Changed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,6 +189,12 @@ impl Calibration {
         }
     }
 
+    fn scale_src_to_ref(&self, src_raw: u64) -> u64 {
+        let delta = src_raw.saturating_sub(self.src_time);
+        let scaled = mul_div_po2_u64(delta, self.scale_factor, self.scale_shift);
+        scaled + self.ref_time
+    }
+
     fn calibrate(&mut self, reference: &Monotonic, source: &Counter) {
         // future improvement: read the TSC frequency directly with something like the
         // code in this PR: https://github.com/hermitcore/uhyve/pull/24
@@ -221,7 +227,7 @@ impl Calibration {
 
             let r_time = reference.now();
             let s_raw = source.now();
-            let s_time = scale_src_to_ref(s_raw, &self);
+            let s_time = self.scale_src_to_ref(s_raw);
             variance.add(s_time as f64 - r_time as f64);
 
             // If we've collected enough samples, check what the mean and mean error are.  If we're
@@ -294,8 +300,7 @@ impl Clock {
     /// Support for TSC, etc, are checked at the time of creation, not compile-time.
     pub fn new() -> Clock {
         let reference = Monotonic::new();
-        let constant_tsc = has_constant_or_better_tsc();
-        let inner = if constant_tsc {
+        let inner = if has_tsc_support() {
             let source = Counter::new();
             let calibration = GLOBAL_CALIBRATION.get_or_init(|| {
                 let mut calibration = Calibration::new();
@@ -414,7 +419,7 @@ impl Clock {
     /// Returns an [`Instant`].
     pub fn scaled(&self, value: u64) -> Instant {
         let scaled = match &self.inner {
-            ClockType::Counter(_, _, _, calibration) => scale_src_to_ref(value, &calibration),
+            ClockType::Counter(_, _, _, calibration) => scale_src_to_ref(value, calibration),
             _ => value,
         };
 
@@ -563,48 +568,14 @@ fn mul_div_po2_u64(value: u64, numer: u64, denom: u32) -> u64 {
 
 #[allow(dead_code)]
 #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
-fn has_constant_or_better_tsc() -> bool {
-    // All of this special handling for CPU manufacturers, specific family/model combinations, etc,
-    // is derived from the Linux kernel, master branch, as of 2020-05-19.
-
-    // We limit ourselves to Intel, AMD, and Centaur.  There are technically other CPUs that
-    // seemingly support constant or better TSC, but there's no chance in hell I have access to
-    // test that out.  People can reach out if they want support.
-    let cpu_mfg = read_cpuid_mfg();
-    match cpu_mfg.as_str() {
-        "GenuineIntel" => {
-            // All Intel processors from the Core microarchitecture and on.
-            if read_cpuid_family_model() >= 0x60E {
-                return true;
-            }
-        }
-        "AuthenticAMD" => {}
-        "CentaurHauls" => {
-            // VIA Nano and above should at least have constant TSC.
-            if read_cpuid_family_model() >= 0x60F {
-                return true;
-            }
-        }
-        // Unknown/unsupported processor.
-        _ => return false,
-    }
-
-    // Check to make sure we have nonstop TSC + RDTSCP support.
+fn has_tsc_support() -> bool {
     read_cpuid_nonstop_tsc() && read_cpuid_rdtscp_support()
 }
 
 #[allow(dead_code)]
 #[cfg(not(all(target_arch = "x86_64", target_feature = "sse2")))]
-fn has_constant_or_better_tsc() -> bool {
+fn has_tsc_support() -> bool {
     false
-}
-
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-fn read_cpuid_mfg() -> String {
-    let cpuid = CpuId::new();
-    cpuid
-        .get_vendor_info()
-        .map_or_else(String::new, |vi| vi.as_str().to_owned())
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -621,14 +592,6 @@ fn read_cpuid_rdtscp_support() -> bool {
     cpuid
         .get_extended_processor_and_feature_identifiers()
         .map_or(false, |efi| efi.has_rdtscp())
-}
-
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-fn read_cpuid_family_model() -> u32 {
-    let cpuid = CpuId::new();
-    cpuid.get_feature_info().map_or(0, |fi| {
-        (fi.family_id() as u32) << 8 | (fi.extended_model_id() as u32) << 4 | fi.model_id() as u32
-    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This should resolve #56 as we were exiting too early from `has_constant_or_better_tsc` simply by looking at the CPU family/model.  In some cases, like virtualized machines, the model/family might be reported as having a good enough TSC source, and we assumed it would also have RDTSC/RDTSCP support by virtue of having SSE2, but it can be toggled on or off... leading to a SIGILL panic.

We now only rely on querying the CPU information directly, checking for invariant TSC and RDTSCP support.

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>