### PR TITLE
Allow Instant to be created from raw u64 values

### DIFF
--- a/src/instant.rs
+++ b/src/instant.rs
@@ -128,6 +128,11 @@ impl Instant {
     pub fn as_u64(&self) -> u64 {
         self.0
     }
+
+    /// Constructs an `Instant` from a raw `u64`.
+    pub fn from_u64(raw: u64) -> Instant {
+        Instant(raw)
+    }
 }
 
 impl Add<Duration> for Instant {


### PR DESCRIPTION
This PR introduces `Instant::from_u64`. This enables the users to take full advantage of the existing `Instant::as_u64` and will enable e.g. the use of atomic operations paired with `Instant`, aiding crates like [atomic-instant](https://crates.io/crates/atomic-instant).