### PR TITLE
Fix clock off by a factor of 1000 in web browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Fixed build issue on x86/x86_64 platforms that did not have SSE.
+- Fixed clock off by a factor of 1000 in wasm/web browser
 
 ## [0.10.0] - 2022-05-18
 

--- a/src/clocks/monotonic/wasm.rs
+++ b/src/clocks/monotonic/wasm.rs
@@ -13,7 +13,7 @@ impl Monotonic {
             .expect(WASM_MISSING_WINDOW_PERF)
             .now();
         // `window.performance.now()` returns the time in milliseconds.
-        return f64::trunc(now * 1000.0) as u64;
+        return f64::trunc(now * 1_000_000.0) as u64;
     }
 }
 


### PR DESCRIPTION
window.performance.now() return milliseconds. As Instant is in nanoseconds, it needs to be multiplied by 1.000.000 not 1.000.

fixes #71 