### PR TITLE
For macos and ios switch from mach crate to mach2 crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,10 +46,10 @@ raw-cpuid = "10.2"
 libc = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-mach = "0.3"
+mach2 = "0.4"
 
 [target.'cfg(target_os = "ios")'.dependencies]
-mach = "0.3"
+mach2 = "0.4"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["profileapi"] }

--- a/src/clocks/monotonic/macos.rs
+++ b/src/clocks/monotonic/macos.rs
@@ -1,4 +1,4 @@
-use mach::mach_time::{mach_absolute_time, mach_timebase_info};
+use mach2::mach_time::{mach_absolute_time, mach_timebase_info};
 
 #[derive(Clone, Copy, Debug)]
 pub struct Monotonic {


### PR DESCRIPTION
mach crate seems abandoned while mach2 crate is more actively updated. Warning has been published in RUSTSEC-2020-0168. This shouldn't have any functional change.

See:
 * https://rustsec.org/advisories/RUSTSEC-2020-0168
 * https://github.com/JohnTitor/mach2/issues/13