### PR TITLE
Avoid contention on `Instant::now()` calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,10 @@ bench = false
 name = "timing"
 harness = false
 
+[[bench]]
+name = "contention"
+harness = false
+
 [features]
 default = ["flaky_tests"]
 flaky_tests = []

--- a/benches/contention.rs
+++ b/benches/contention.rs
@@ -1,0 +1,61 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use quanta::Instant as QuantaInstant;
+use std::{
+    sync::Mutex,
+    thread,
+    time::{Duration, Instant as StdInstant},
+};
+
+const MAX_THREAD_COUNT: u32 = 12;
+
+fn run<I>(thread_count: u32, iter_count: u64, now: impl Fn() -> I + Sync) -> Duration {
+    let max_duration = Mutex::new(Duration::new(0, 0));
+
+    thread::scope(|s| {
+        for _ in 0..thread_count {
+            s.spawn(|| {
+                let start = StdInstant::now();
+
+                for _ in 0..iter_count {
+                    black_box(now());
+                }
+
+                let duration = start.elapsed();
+                let mut max_duration = max_duration.lock().unwrap();
+                *max_duration = max_duration.max(duration);
+            });
+        }
+    });
+
+    let max = *max_duration.lock().unwrap();
+    max
+}
+
+fn benchmark(c: &mut Criterion) {
+    let mut std_group = c.benchmark_group("stdlib");
+    for thread_count in 1..=MAX_THREAD_COUNT {
+        std_group.bench_with_input(
+            BenchmarkId::new("now", thread_count),
+            &thread_count,
+            |b, &thread_count| {
+                b.iter_custom(|iter_count| run(thread_count, iter_count, StdInstant::now));
+            },
+        );
+    }
+    std_group.finish();
+
+    let mut q_group = c.benchmark_group("quanta");
+    for thread_count in 1..=MAX_THREAD_COUNT {
+        q_group.bench_with_input(
+            BenchmarkId::new("now", thread_count),
+            &thread_count,
+            |b, &thread_count| {
+                b.iter_custom(|iter_count| run(thread_count, iter_count, QuantaInstant::now));
+            },
+        );
+    }
+    q_group.finish();
+}
+
+criterion_group!(benches, benchmark);
+criterion_main!(benches);

--- a/benches/timing.rs
+++ b/benches/timing.rs
@@ -3,7 +3,7 @@ use quanta::{Clock, Instant as QuantaInstant};
 use std::time::Instant as StdInstant;
 
 fn time_instant_now(b: &mut Bencher) {
-    b.iter(|| StdInstant::now())
+    b.iter(StdInstant::now)
 }
 
 fn time_quanta_now(b: &mut Bencher) {
@@ -13,7 +13,7 @@ fn time_quanta_now(b: &mut Bencher) {
 
 fn time_quanta_instant_now(b: &mut Bencher) {
     let _ = QuantaInstant::now();
-    b.iter(|| QuantaInstant::now());
+    b.iter(QuantaInstant::now);
 }
 
 fn time_quanta_raw(b: &mut Bencher) {

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -136,6 +136,33 @@ impl Instant {
         self.checked_duration_since(earlier).unwrap_or_default()
     }
 
+    /// Returns the amount of time elapsed since this instant was created.
+    ///
+    /// # Panics
+    ///
+    /// Previous `quanta` versions panicked when the current time was earlier than self.
+    /// Currently this method returns a Duration of zero in that case.
+    /// Future versions may reintroduce the panic. See [Monotonicity].
+    ///
+    /// [Monotonicity]: Instant#monotonicity
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use quanta::Clock;
+    /// use std::time::Duration;
+    /// use std::thread::sleep;
+    ///
+    /// let mut clock = Clock::new();
+    /// let now = clock.now();
+    /// sleep(Duration::new(1, 0));
+    /// let elapsed = now.elapsed();
+    /// println!("{:?}", elapsed); // ≥ 1s
+    /// ```
+    pub fn elapsed(&self) -> Duration {
+        Instant::now() - *self
+    }
+
     /// Returns `Some(t)` where `t` is the time `self + duration` if `t` can be represented as
     /// `Instant` (which means it's inside the bounds of the underlying data structure), `None`
     /// otherwise.


### PR DESCRIPTION
Results (performed on an [AMD Ryzen 7 4800HS CPU](https://en.wikichip.org/wiki/amd/ryzen_9/3900)):
```
group            main                                    no-contention
-----            ----                                    -------------
quanta/now/1     1.33     18.8±9.87ns        ? ?/sec     1.00     14.2±7.40ns        ? ?/sec
quanta/now/10    13.38  345.7±54.28ns        ? ?/sec     1.00    25.8±10.19ns        ? ?/sec
quanta/now/11    15.72  394.6±37.46ns        ? ?/sec     1.00     25.1±8.89ns        ? ?/sec
quanta/now/12    17.74  457.2±59.94ns        ? ?/sec     1.00     25.8±9.02ns        ? ?/sec
quanta/now/2     3.23    53.6±12.42ns        ? ?/sec     1.00     16.6±5.66ns        ? ?/sec
quanta/now/3     6.11   100.7±35.62ns        ? ?/sec     1.00     16.5±5.76ns        ? ?/sec
quanta/now/4     9.31   160.2±43.22ns        ? ?/sec     1.00     17.2±5.69ns        ? ?/sec
quanta/now/5     10.32  182.0±38.35ns        ? ?/sec     1.00     17.6±5.71ns        ? ?/sec
quanta/now/6     11.92  205.4±61.60ns        ? ?/sec     1.00     17.2±5.86ns        ? ?/sec
quanta/now/7     13.92  244.1±65.22ns        ? ?/sec     1.00     17.5±6.55ns        ? ?/sec
quanta/now/8     15.56  269.7±60.34ns        ? ?/sec     1.00     17.3±6.17ns        ? ?/sec
quanta/now/9     12.79  309.2±87.00ns        ? ?/sec     1.00     24.2±9.47ns        ? ?/sec
stdlib/now/1     1.03  1165.6±142.16ns        ? ?/sec    1.00  1126.9±71.75ns        ? ?/sec
stdlib/now/10    1.00  1368.3±30.03ns        ? ?/sec     1.01  1386.1±75.49ns        ? ?/sec
stdlib/now/11    1.00  1401.8±70.33ns        ? ?/sec     1.00  1401.1±68.81ns        ? ?/sec
stdlib/now/12    1.00  1389.6±48.94ns        ? ?/sec     1.00  1387.9±38.73ns        ? ?/sec
stdlib/now/2     1.00  1358.9±105.26ns        ? ?/sec    1.05  1431.1±147.48ns        ? ?/sec
stdlib/now/3     1.00  1380.8±55.35ns        ? ?/sec     1.00  1382.1±73.67ns        ? ?/sec
stdlib/now/4     1.05  1428.2±133.49ns        ? ?/sec    1.00  1363.3±65.90ns        ? ?/sec
stdlib/now/5     1.01  1391.0±117.71ns        ? ?/sec    1.00  1374.8±60.66ns        ? ?/sec
stdlib/now/6     1.02  1365.4±63.80ns        ? ?/sec     1.00  1344.3±46.68ns        ? ?/sec
stdlib/now/7     1.02  1387.7±76.32ns        ? ?/sec     1.00  1363.6±53.60ns        ? ?/sec
stdlib/now/8     1.01  1411.2±115.90ns        ? ?/sec    1.00  1398.2±92.98ns        ? ?/sec
stdlib/now/9     1.03  1416.0±93.12ns        ? ?/sec     1.00  1374.0±56.60ns        ? ?/sec
```

TODO:
* Add README to `benches` with results.

Closes #81