### PR TITLE
Clock.delta_as_nanos, a delta that skips conversion to Duration

### DIFF
--- a/benches/timing.rs
+++ b/benches/timing.rs
@@ -43,6 +43,15 @@ fn time_quanta_raw_delta(b: &mut Bencher) {
     })
 }
 
+fn time_quanta_raw_delta_as_nanos(b: &mut Bencher) {
+    let clock = Clock::new();
+    b.iter(|| {
+        let start = clock.raw();
+        let end = clock.raw();
+        clock.delta_as_nanos(start, end)
+    })
+}
+
 fn time_quanta_now_delta(b: &mut Bencher) {
     let clock = Clock::new();
     b.iter(|| {
@@ -75,6 +84,7 @@ fn benchmark(c: &mut Criterion) {
     q_group.bench_function("quanta_raw", time_quanta_raw);
     q_group.bench_function("quanta_raw_scaled", time_quanta_raw_scaled);
     q_group.bench_function("quanta_raw_delta", time_quanta_raw_delta);
+    q_group.bench_function("quanta_raw_delta_as_nanos", time_quanta_raw_delta_as_nanos);
     q_group.bench_function("quanta_recent", time_quanta_recent);
     q_group.bench_function("quanta_instant_recent", time_quanta_instant_recent);
     q_group.finish();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -388,8 +388,7 @@ impl Clock {
         Instant(scaled)
     }
 
-    /// Calculates the delta in nanoseconds scaled to reference time in nanoseconds
-    /// between two measurements.
+    /// Calculates the delta, in nanoseconds, between two raw measurements.
     ///
     /// This method is very similar to [`delta`] but reduces overhead
     /// for high-frequency measurements that work with nanosecond
@@ -415,14 +414,15 @@ impl Clock {
         }
     }
 
-    /// Calculates the delta between two measurements, and scales to reference time.
+    /// Calculates the delta between two raw measurements.
     ///
     /// This method is slightly faster when you know you need the delta between two raw
     /// measurements, or a start/end measurement, than using [`scaled`] for both conversions.
     ///
-    /// In code that uses `clock.delta(start, end).as_nanos()` with
-    /// high frequency, consider [`delta_as_nanos`] instead, as that
-    /// avoids the round-trip conversion through [`Duration`].
+   /// In code that simply needs access to the whole number of nanoseconds
+   /// between the two measurements, consider [`Clock::delta_as_nanos`]
+   /// instead, which is slightly faster than having to call both this method
+   /// and [`Duration::as_nanos`].
     ///
     /// [`scaled`]: Clock::scaled
     /// [`delta_as_nanos`]: Clock::delta_as_nanos

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -388,29 +388,46 @@ impl Clock {
         Instant(scaled)
     }
 
-    /// Calculates the delta between two measurements, and scales to reference time.
+    /// Calculates the delta in nanoseconds scaled to reference time in nanoseconds
+    /// between two measurements.
     ///
-    /// This method is slightly faster when you know you need the delta between two raw
-    /// measurements, or a start/end measurement, than using [`scaled`] for both conversions.
+    /// This method is very similar to [`delta`] but reduces overhead
+    /// for high-frequency measurements that work with nanosecond
+    /// counts internally, as it avoids the conversion of the delta
+    /// into [`Duration`].
     ///
-    /// [`scaled`]: Clock::scaled
-    pub fn delta(&self, start: u64, end: u64) -> Duration {
+    /// [`delta`]: Clock::delta
+    pub fn delta_as_nanos(&self, start: u64, end: u64) -> u64 {
         // Safety: we want wrapping_sub on the end/start delta calculation so that two measurements
         // split across a rollover boundary still return the right result.  However, we also know
         // the TSC could potentially give us different values between cores/sockets, so we're just
         // doing our due diligence here to make sure we're not about to create some wacky duration.
         if end <= start {
-            return Duration::new(0, 0);
+            return 0;
         }
 
         let delta = end.wrapping_sub(start);
-        let scaled = match &self.inner {
+        match &self.inner {
             ClockType::Counter(_, _, calibration) => {
                 mul_div_po2_u64(delta, calibration.scale_factor, calibration.scale_shift)
             }
             _ => delta,
-        };
-        Duration::from_nanos(scaled)
+        }
+    }
+
+    /// Calculates the delta between two measurements, and scales to reference time.
+    ///
+    /// This method is slightly faster when you know you need the delta between two raw
+    /// measurements, or a start/end measurement, than using [`scaled`] for both conversions.
+    ///
+    /// In code that uses `clock.delta(start, end).as_nanos()` with
+    /// high frequency, consider [`delta_as_nanos`] instead, as that
+    /// avoids the round-trip conversion through [`Duration`].
+    ///
+    /// [`scaled`]: Clock::scaled
+    /// [`delta_as_nanos`]: Clock::delta_as_nanos
+    pub fn delta(&self, start: u64, end: u64) -> Duration {
+        Duration::from_nanos(self.delta_as_nanos(start, end))
     }
 
     /// Gets the most recent current time, scaled to reference time.


### PR DESCRIPTION
This change addresses #84.

## Relevant Benchmarks

These look great - 2ns on the mac and 7ns on my linux testbed: I think high-frequency usage of the raw quanta functions will benefit a lot from using `delta_as_nanos`.

### macOS (m1 max)

```
quanta/quanta_raw_delta time:   [16.591 ns 16.620 ns 16.648 ns]
Found 26 outliers among 100 measurements (26.00%)
  6 (6.00%) low severe
  2 (2.00%) low mild
  5 (5.00%) high mild
  13 (13.00%) high severe
quanta/quanta_raw_delta_as_nanos
                        time:   [14.150 ns 14.163 ns 14.176 ns]
Found 12 outliers among 100 measurements (12.00%)
  5 (5.00%) high mild
  7 (7.00%) high severe
```

### Linux (dual Xeon Silver 4114)

```
quanta/quanta_raw_delta time:   [24.551 ns 24.686 ns 24.841 ns]
Found 11 outliers among 100 measurements (11.00%)
  8 (8.00%) high mild
  3 (3.00%) high severe
quanta/quanta_raw_delta_as_nanos
                        time:   [17.353 ns 17.517 ns 17.704 ns]
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe
```