### PR TITLE
Try and fix CI for MIPS/MIPSEL.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
     - name: Install Cross
       run: cargo install cross --git https://github.com/cross-rs/cross
     - name: Run Tests
-      run: cross test --target ${{ matrix.target }} --no-default-features --features=prost -- --test-threads=1
+      run: cross +nightly test --target ${{ matrix.target }} --no-default-features --features=prost -- --test-threads=1
       env:
         RUSTFLAGS: "-C opt-level=1"
   docs:

--- a/Cross.toml
+++ b/Cross.toml
@@ -3,3 +3,9 @@ build-std = true
 
 [target.mips-unknown-linux-gnu.env]
 passthrough = ["RUSTFLAGS"]
+
+[target.mipsel-unknown-linux-gnu]
+build-std = true
+
+[target.mipsel-unknown-linux-gnu.env]
+passthrough = ["RUSTFLAGS"]


### PR DESCRIPTION
Seems like something changed recently with the tier/priority for MIPS/MIPSEL so we need to use the nightly compiler to get `core`/`std`. We also have one additional change to deal with MIPS having symbol relocation issues unless optimizations are enabled. (:shrug:)