### PR TITLE
Populate global recent time before `Upkeep` starts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -438,14 +438,12 @@ impl Clock {
     /// read directly without the need to scale to reference time.
     ///
     /// The upkeep thread must be started in order to update the time.  You can read the
-    /// documentation for [`Upkeep`][upkeep] for more information on starting the upkeep thread, as
+    /// documentation for [`Upkeep`] for more information on starting the upkeep thread, as
     /// well as the details of the "current time" mechanism.
     ///
     /// If the upkeep thread has not been started, the return value will be `0`.
     ///
     /// Returns an [`Instant`].
-    ///
-    /// [upkeep]: crate::Upkeep
     pub fn recent(&self) -> Instant {
         match &self.inner {
             ClockType::Mock(mock) => Instant(mock.value()),

--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -120,6 +120,11 @@ impl Upkeep {
         let interval = self.interval;
         let clock = self.clock;
 
+        // Note: spawning `quanta-upkeep` thread may take a significant amount of time. Thus, it is
+        // possible for a user to read a 0 value from `Clock::recent` before `quanta-upkeep` has
+        // started. To avoid that, make sure the recent time is initialized to some measurement.
+        set_recent(clock.now());
+
         let done = Arc::new(AtomicBool::new(false));
         let their_done = done.clone();
 


### PR DESCRIPTION
Closes #94 