### PR TITLE
docs: fix typo {windows => window}.performance.now

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@
 //!
 //! This library can be built for WASM targets, but in this case the resolution and accuracy of
 //! measurements can be limited by the WASM environment. In particular, when running on the
-//! `wasm32-unknown-unknown` target in browsers, `quanta` will use [windows.performance.now] as a
+//! `wasm32-unknown-unknown` target in browsers, `quanta` will use [window.performance.now] as a
 //! clock. This mean the accuracy is limited to milliseconds instead of the usual nanoseconds on
 //! other targets. When running within a WASI environment (target `wasm32-wasi`), the accuracy of
 //! the clock depends on the VM implementation.
@@ -135,7 +135,7 @@
 //! [mach_absolute_time]: https://developer.apple.com/documentation/kernel/1462446-mach_absolute_time
 //! [clock_gettime]: https://linux.die.net/man/3/clock_gettime
 //! [prost_types_timestamp]: https://docs.rs/prost-types/0.7.0/prost_types/struct.Timestamp.html
-//! [windows.performance.now]: https://developer.mozilla.org/en-US/docs/Web/API/Performance/now
+//! [window.performance.now]: https://developer.mozilla.org/en-US/docs/Web/API/Performance/now
 #![deny(missing_docs)]
 #![deny(clippy::all)]
 #![allow(clippy::must_use_candidate)]


### PR DESCRIPTION
Just a small typo I noticed why reading the docs. I hope these drive by PRs aren't unwelcome