### PR TITLE
fix: lossy truncation in checked `Instant` arithmetic

### DIFF
--- a/src/instant.rs
+++ b/src/instant.rs
@@ -395,7 +395,5 @@ mod tests {
         assert_ne!(Duration::ZERO, dur);
         assert_ne!(Some(now), behind);
         assert_ne!(Some(now), ahead);
-        assert_eq!(None, behind);
-        assert_eq!(None, ahead);
     }
 }

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -376,6 +376,10 @@ mod tests {
 
     // Test fix for issue #109
     #[test]
+    #[cfg_attr(
+        all(target_arch = "wasm32", target_os = "unknown"),
+        wasm_bindgen_test::wasm_bindgen_test
+    )]
     fn checked_arithmetic_u64_overflow() {
         fn nanos_to_dur(total_nanos: u128) -> Duration {
             let nanos_per_sec = Duration::from_secs(1).as_nanos();

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -171,14 +171,16 @@ impl Instant {
     /// `Instant` (which means it's inside the bounds of the underlying data structure), `None`
     /// otherwise.
     pub fn checked_add(&self, duration: Duration) -> Option<Instant> {
-        self.0.checked_add(duration.as_nanos() as u64).map(Instant)
+        let total_nanos: u64 = duration.as_nanos().try_into().ok()?;
+        self.0.checked_add(total_nanos).map(Instant)
     }
 
     /// Returns `Some(t)` where `t` is the time `self - duration` if `t` can be represented as
     /// `Instant` (which means it's inside the bounds of the underlying data structure), `None`
     /// otherwise.
     pub fn checked_sub(&self, duration: Duration) -> Option<Instant> {
-        self.0.checked_sub(duration.as_nanos() as u64).map(Instant)
+        let total_nanos: u64 = duration.as_nanos().try_into().ok()?;
+        self.0.checked_sub(total_nanos).map(Instant)
     }
 }
 
@@ -370,5 +372,30 @@ mod tests {
             let t4 = Instant::recent();
             assert_eq!(t4.0, 1440);
         })
+    }
+
+    // Test fix for issue #109
+    #[test]
+    fn checked_arithmetic_u64_overflow() {
+        fn nanos_to_dur(total_nanos: u128) -> Duration {
+            let nanos_per_sec = Duration::from_secs(1).as_nanos();
+            let secs = total_nanos / nanos_per_sec;
+            let nanos = total_nanos % nanos_per_sec;
+            let dur = Duration::new(secs as _, nanos as _);
+            assert_eq!(dur.as_nanos(), total_nanos);
+            dur
+        }
+
+        let dur = nanos_to_dur(1 << 64);
+        let now = Instant::now();
+
+        let behind = now.checked_sub(dur);
+        let ahead = now.checked_add(dur);
+
+        assert_ne!(Duration::ZERO, dur);
+        assert_ne!(Some(now), behind);
+        assert_ne!(Some(now), ahead);
+        assert_eq!(None, behind);
+        assert_eq!(None, ahead);
     }
 }

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -171,7 +171,7 @@ impl Instant {
     /// `Instant` (which means it's inside the bounds of the underlying data structure), `None`
     /// otherwise.
     pub fn checked_add(&self, duration: Duration) -> Option<Instant> {
-        let total_nanos: u64 = duration.as_nanos().try_into().ok()?;
+        let total_nanos = u64::try_from(duration.as_nanos()).ok()?;
         self.0.checked_add(total_nanos).map(Instant)
     }
 
@@ -179,7 +179,7 @@ impl Instant {
     /// `Instant` (which means it's inside the bounds of the underlying data structure), `None`
     /// otherwise.
     pub fn checked_sub(&self, duration: Duration) -> Option<Instant> {
-        let total_nanos: u64 = duration.as_nanos().try_into().ok()?;
+        let total_nanos = u64::try_from(duration.as_nanos()).ok()?;
         self.0.checked_sub(total_nanos).map(Instant)
     }
 }


### PR DESCRIPTION
Fixes and tests https://github.com/metrics-rs/quanta/issues/109.

## Unresolved Questions
- [X] ~~The test case currently asserts that offsets of `1 << 64` nanos always overflow, which relies on `Instant`s being implemented as 64-bit nanosecond counts. It would be correct just to check that the `Instant` is not left unchanged, so should I remove those last two assertions?~~ Removed as of caae534f0c987bb2822a95370a96c618a9613304