### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         rust_version: ['1.70.0', 'stable', 'nightly']
-        os: [ubuntu-22.04, ubuntu-24.04, macOS-13, macOS-14, windows-2019, windows-2022]
+        os: [ubuntu-22.04, ubuntu-24.04, macOS-13, macOS-14, windows-2022]
     steps:
     - uses: actions/checkout@v3
     - name: Install Rust ${{ matrix.rust_version }}
@@ -80,7 +80,7 @@ jobs:
     strategy:
       matrix:
         rust_version: ['1.70.0', 'stable', 'nightly']
-        os: [ubuntu-22.04, ubuntu-24.04, macOS-13, macOS-14, windows-2019, windows-2022]
+        os: [ubuntu-22.04, ubuntu-24.04, macOS-13, macOS-14, windows-2022]
     steps:
     - uses: actions/checkout@v3
     - name: Install Rust ${{ matrix.rust_version }}
@@ -91,25 +91,26 @@ jobs:
       run: cargo install wasm-pack
     - name: Run Tests
       run: wasm-pack test --node
-  test-wasi:
-    name: Test ${{ matrix.rust_version }}/${{ matrix.os }} (wasm32-wasi)
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        rust_version: ['1.70.0', 'stable', 'nightly']
-        os: [ubuntu-22.04, ubuntu-24.04, macOS-13, macOS-14, windows-2019, windows-2022]
-    steps:
-    - uses: actions/checkout@v3
-    - name: Install Rust ${{ matrix.rust_version }}
-      run: rustup default ${{ matrix.rust_version }}
-    - name: Install wasm32-wasi target
-      run: rustup target add wasm32-wasi
-    - name: Install cargo-wasi
-      run: cargo install cargo-wasi
-    - name: Install wasmtime
-      run: curl https://wasmtime.dev/install.sh -sSf | bash
-    - name: Run Tests
-      run: cargo wasi test
+  # TODO: Migrate to https://github.com/bytecodealliance/cargo-component
+  #test-wasi:
+  #  name: Test ${{ matrix.rust_version }}/${{ matrix.os }} (wasm32-wasi)
+  #  runs-on: ${{ matrix.os }}
+  #  strategy:
+  #    matrix:
+  #      rust_version: ['1.70.0', 'stable', 'nightly']
+  #      os: [ubuntu-22.04, ubuntu-24.04, macOS-13, macOS-14, windows-2022]
+  #  steps:
+  #  - uses: actions/checkout@v3
+  #  - name: Install Rust ${{ matrix.rust_version }}
+  #    run: rustup default ${{ matrix.rust_version }}
+  #  - name: Install wasm32-wasi target
+  #    run: rustup target add wasm32-wasi
+  #  - name: Install cargo-wasi
+  #    run: cargo install cargo-wasi
+  #  - name: Install wasmtime
+  #    run: curl https://wasmtime.dev/install.sh -sSf | bash
+  #  - name: Run Tests
+  #    run: cargo wasi test
   docs:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
I've tested these changes on my fork repo and all workflows pass.

The changes:
*  windows 2019 is no longer supported by github actions, so it is removed from our workflows
* The `cargo wasi` [repo is archived](https://github.com/bytecodealliance/cargo-wasi) and [the recent change by the rust project to rename the wasm32-wasi target to wasm32-wasip1](https://blog.rust-lang.org/2024/04/09/updates-to-rusts-wasi-targets/) has broken `cargo wasi` as it is stuck using the now nonexistant `wasm32-wasi` target. While this whole thing is very silly and could probably be resolved by forking `cargo-wasm` and changing the name of the target, since upstream is so broken, I dont think theres much point in maintaining the CI for `cargo-wasm`/`wasm32-wasip1`. The future seems to be in `cargo-component`/`wasm32-wasp2`, so any future work on CI should be done to use that. However, I could not find an easy to run tests with `cargo-component` so I'm thinking its best to just disable the existing `wasm32-wasip1` workflow and let someone with more wasm experience come along and fix it.