### PR TITLE
Remove `once_cell` dep by replacing `once_cell::sync::OnceCell` with `std::sync::OnceLock`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Install Rust ${{ matrix.rust_version }}
       run: rustup default ${{ matrix.rust_version }}
     - name: Run Tests
-      run: cargo test --no-default-features --features=prost -- --test-threads=1
+      run: cargo test --no-default-features --features=prost
   cross-test:
     name: Test ${{ matrix.target }}
     runs-on: ubuntu-latest
@@ -55,7 +55,7 @@ jobs:
     - name: Install Cross
       run: cargo install cross --git https://github.com/cross-rs/cross
     - name: Run Tests
-      run: cross test --target ${{ matrix.target }} --no-default-features --features=prost -- --test-threads=1
+      run: cross test --target ${{ matrix.target }} --no-default-features --features=prost
   cross-test-mips-mipssel:
     name: Test ${{ matrix.target }}
     runs-on: ubuntu-latest
@@ -71,7 +71,7 @@ jobs:
     - name: Install Cross
       run: cargo install cross --git https://github.com/cross-rs/cross
     - name: Run Tests
-      run: cross +nightly test --target ${{ matrix.target }} --no-default-features --features=prost -- --test-threads=1
+      run: cross +nightly test --target ${{ matrix.target }} --no-default-features --features=prost
       env:
         RUSTFLAGS: "-C opt-level=1"
   test-wasm-browser:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ wasi = "0.11"
 [dev-dependencies]
 average = "0.14"
 criterion = "=0.3.3"
+serial_test = "3.2"
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ flaky_tests = []
 prost = ["prost-types"]
 
 [dependencies]
-once_cell = "1.4"
 prost-types = { version = "0.11", default-features = false, optional = true }
 crossbeam-utils = "0.8.5"
 

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -279,20 +279,18 @@ impl Into<prost_types::Timestamp> for Instant {
 
 #[cfg(test)]
 mod tests {
-    use once_cell::sync::Lazy;
-
     use super::Instant;
     use crate::{with_clock, Clock};
+    use serial_test::serial;
+    use std::thread;
     use std::time::Duration;
-    use std::{sync::Mutex, thread};
-
-    static RECENT_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
     #[test]
     #[cfg_attr(
         all(target_arch = "wasm32", target_os = "unknown"),
         ignore = "WASM thread cannot sleep"
     )]
+    #[serial]
     fn test_now() {
         let t0 = Instant::now();
         thread::sleep(Duration::from_millis(15));
@@ -311,9 +309,8 @@ mod tests {
         all(target_arch = "wasm32", target_os = "unknown"),
         ignore = "WASM thread cannot sleep"
     )]
+    #[serial]
     fn test_recent() {
-        let _guard = RECENT_LOCK.lock().unwrap();
-
         // Ensures that the recent global value is zero so that the fallback logic can kick in.
         crate::set_recent(Instant(0));
 
@@ -346,9 +343,8 @@ mod tests {
         all(target_arch = "wasm32", target_os = "unknown"),
         wasm_bindgen_test::wasm_bindgen_test
     )]
+    #[serial]
     fn test_mocking() {
-        let _guard = RECENT_LOCK.lock().unwrap();
-
         // Ensures that the recent global value is zero so that the fallback logic can kick in.
         crate::set_recent(Instant(0));
 
@@ -380,6 +376,7 @@ mod tests {
         all(target_arch = "wasm32", target_os = "unknown"),
         wasm_bindgen_test::wasm_bindgen_test
     )]
+    #[serial]
     fn checked_arithmetic_u64_overflow() {
         fn nanos_to_dur(total_nanos: u128) -> Duration {
             let nanos_per_sec = Duration::from_secs(1).as_nanos();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,10 +141,9 @@
 #![allow(clippy::must_use_candidate)]
 
 use crossbeam_utils::atomic::AtomicCell;
+use std::sync::OnceLock;
 use std::time::Duration;
 use std::{cell::RefCell, sync::Arc};
-
-use once_cell::sync::OnceCell;
 
 mod clocks;
 use self::clocks::{Counter, Monotonic};
@@ -159,13 +158,13 @@ mod stats;
 use self::stats::Variance;
 
 // Global clock, used by `Instant::now`.
-static GLOBAL_CLOCK: OnceCell<Clock> = OnceCell::new();
+static GLOBAL_CLOCK: OnceLock<Clock> = OnceLock::new();
 
 // Global recent measurement, used by `Clock::recent` and `Instant::recent`.
 static GLOBAL_RECENT: AtomicCell<u64> = AtomicCell::new(0);
 
 // Global calibration, shared by all clocks.
-static GLOBAL_CALIBRATION: OnceCell<Calibration> = OnceCell::new();
+static GLOBAL_CALIBRATION: OnceLock<Calibration> = OnceLock::new();
 
 // Per-thread clock override, used by `quanta::with_clock`, `Instant::now`, and sometimes `Instant::recent`.
 thread_local! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -542,6 +542,7 @@ fn mul_div_po2_u64(value: u64, numer: u64, denom: u32) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::Clock;
+    use serial_test::serial;
 
     #[cfg(not(target_arch = "wasm32"))]
     use super::{Counter, Monotonic};
@@ -557,6 +558,7 @@ mod tests {
         all(target_arch = "wasm32", target_os = "unknown"),
         wasm_bindgen_test::wasm_bindgen_test
     )]
+    #[serial]
     fn test_mock() {
         let (clock, mock) = Clock::mock();
         assert_eq!(clock.now().0, 0);
@@ -565,6 +567,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     #[cfg_attr(
         all(target_arch = "wasm32", target_os = "unknown"),
         wasm_bindgen_test::wasm_bindgen_test
@@ -575,6 +578,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     #[cfg_attr(
         all(target_arch = "wasm32", target_os = "unknown"),
         wasm_bindgen_test::wasm_bindgen_test
@@ -585,6 +589,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     #[cfg_attr(
         all(target_arch = "wasm32", target_os = "unknown"),
         wasm_bindgen_test::wasm_bindgen_test
@@ -598,6 +603,7 @@ mod tests {
 
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
+    #[serial]
     #[cfg_attr(not(feature = "flaky_tests"), ignore)]
     fn test_reference_source_calibration() {
         let mut clock = Clock::new();
@@ -681,6 +687,7 @@ mod tests {
 
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
+    #[serial]
     #[cfg_attr(not(feature = "flaky_tests"), ignore)]
     fn measure_source_reference_self_timing() {
         let source = Counter::default();

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -61,8 +61,10 @@ impl Variance {
 #[cfg(test)]
 mod tests {
     use super::Variance;
+    use serial_test::serial;
 
     #[test]
+    #[serial]
     fn basic() {
         let inputs = &[5.0, 10.0, 12.0, 15.0, 20.0];
         let mut variance = Variance::default();

--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -170,10 +170,12 @@ impl Drop for Handle {
 #[cfg(test)]
 mod tests {
     use super::Upkeep;
+    use serial_test::serial;
     use std::time::Duration;
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", ignore)] // WASM is single threaded
+    #[serial]
     fn test_spawning_second_upkeep() {
         let first = Upkeep::new(Duration::from_millis(250)).start();
         let second = Upkeep::new(Duration::from_millis(250))


### PR DESCRIPTION
https://doc.rust-lang.org/std/sync/struct.OnceLock.html was introduced in rust 1.70.0 which falls within this projects MSRV of 1.70.0 (according to the github actions config)
As such we can just replace the usage of OnceCell with OnceLock to remove the once_cell dependency.

There were some tests using `once_cell::sync::Lazy` in what appears to be an attempt to prevent race conditions in concurrently running tests.
However, this does not help as I still observed test failures locally and needed to set `--test-threads 1`. (In fact CI is setup to run `--test-threads 1` anyway)
So I opted to just remove this usage entirely.

If the usage in tests was important, I am happy to do one of:
* use [serial_test](https://github.com/palfrey/serial_test) instead.
* restore the original functionality and set once_cell as a dev-dependency.
* restore the original functionality by using https://doc.rust-lang.org/std/sync/struct.LazyLock.html (requires bumping msrv to 1.80.0)