### PR TITLE
feat: gate mock support behind "mock" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,9 @@ name = "contention"
 harness = false
 
 [features]
-default = ["flaky_tests"]
+default = ["flaky_tests", "mock"]
 flaky_tests = []
+mock = []
 prost = ["prost-types"]
 
 [dependencies]

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -282,6 +282,7 @@ mod tests {
     use once_cell::sync::Lazy;
 
     use super::Instant;
+    #[cfg(feature = "mock")]
     use crate::{with_clock, Clock};
     use std::time::Duration;
     use std::{sync::Mutex, thread};
@@ -341,6 +342,7 @@ mod tests {
         assert_eq!(t2, t3);
     }
 
+    #[cfg(feature = "mock")]
     #[test]
     #[cfg_attr(
         all(target_arch = "wasm32", target_os = "unknown"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,15 +141,19 @@
 #![allow(clippy::must_use_candidate)]
 
 use crossbeam_utils::atomic::AtomicCell;
-use std::time::Duration;
-use std::{cell::RefCell, sync::Arc};
-
 use once_cell::sync::OnceCell;
+#[cfg(feature = "mock")]
+use std::cell::RefCell;
+#[cfg(feature = "mock")]
+use std::sync::Arc;
+use std::time::Duration;
 
 mod clocks;
 use self::clocks::{Counter, Monotonic};
 mod detection;
+#[cfg(feature = "mock")]
 mod mock;
+#[cfg(feature = "mock")]
 pub use self::mock::{IntoNanoseconds, Mock};
 mod instant;
 pub use self::instant::Instant;
@@ -168,6 +172,7 @@ static GLOBAL_RECENT: AtomicCell<u64> = AtomicCell::new(0);
 static GLOBAL_CALIBRATION: OnceCell<Calibration> = OnceCell::new();
 
 // Per-thread clock override, used by `quanta::with_clock`, `Instant::now`, and sometimes `Instant::recent`.
+#[cfg(feature = "mock")]
 thread_local! {
     static CLOCK_OVERRIDE: RefCell<Option<Clock>> = RefCell::new(None);
 }
@@ -185,6 +190,7 @@ const MAXIMUM_CAL_TIME_NS: u64 = 200 * 1000 * 1000;
 enum ClockType {
     Monotonic(Monotonic),
     Counter(Monotonic, Counter, Calibration),
+    #[cfg(feature = "mock")]
     Mock(Arc<Mock>),
 }
 
@@ -334,6 +340,7 @@ impl Clock {
     ///
     /// Returns a [`Clock`] instance and a handle to the underlying [`Mock`] source so that the
     /// caller can control the passage of time.
+    #[cfg(feature = "mock")]
     pub fn mock() -> (Clock, Arc<Mock>) {
         let mock = Arc::new(Mock::new());
         let clock = Clock {
@@ -353,6 +360,7 @@ impl Clock {
         match &self.inner {
             ClockType::Monotonic(monotonic) => Instant(monotonic.now()),
             ClockType::Counter(_, counter, _) => self.scaled(counter.now()),
+            #[cfg(feature = "mock")]
             ClockType::Mock(mock) => Instant(mock.value()),
         }
     }
@@ -369,6 +377,7 @@ impl Clock {
         match &self.inner {
             ClockType::Monotonic(monotonic) => monotonic.now(),
             ClockType::Counter(_, counter, _) => counter.now(),
+            #[cfg(feature = "mock")]
             ClockType::Mock(mock) => mock.value(),
         }
     }
@@ -446,6 +455,7 @@ impl Clock {
     /// Returns an [`Instant`].
     pub fn recent(&self) -> Instant {
         match &self.inner {
+            #[cfg(feature = "mock")]
             ClockType::Mock(mock) => Instant(mock.value()),
             _ => Instant(GLOBAL_RECENT.load()),
         }
@@ -474,6 +484,7 @@ impl Default for Clock {
 impl Clone for ClockType {
     fn clone(&self) -> Self {
         match self {
+            #[cfg(feature = "mock")]
             ClockType::Mock(mock) => ClockType::Mock(mock.clone()),
             ClockType::Monotonic(monotonic) => ClockType::Monotonic(*monotonic),
             ClockType::Counter(monotonic, counter, calibration) => {
@@ -487,12 +498,20 @@ impl Clone for ClockType {
 ///
 /// This will only affect calls made against [`Instant`].  [`Clock`] is always self-contained.
 pub fn with_clock<T>(clock: &Clock, f: impl FnOnce() -> T) -> T {
-    CLOCK_OVERRIDE.with(|current| {
-        let old = current.replace(Some(clock.clone()));
-        let result = f();
-        current.replace(old);
-        result
-    })
+    #[cfg(feature = "mock")]
+    {
+        CLOCK_OVERRIDE.with(|current| {
+            let old = current.replace(Some(clock.clone()));
+            let result = f();
+            current.replace(old);
+            result
+        })
+    }
+    #[cfg(not(feature = "mock"))]
+    {
+        let _ = clock;
+        f()
+    }
 }
 
 /// Sets the global recent time.
@@ -507,11 +526,11 @@ pub fn set_recent(instant: Instant) {
 
 #[inline]
 pub(crate) fn get_now() -> Instant {
+    #[cfg(feature = "mock")]
     if let Some(instant) = CLOCK_OVERRIDE.with(|clock| clock.borrow().as_ref().map(Clock::now)) {
-        instant
-    } else {
-        GLOBAL_CLOCK.get_or_init(Clock::new).now()
+        return instant;
     }
+    GLOBAL_CLOCK.get_or_init(Clock::new).now()
 }
 
 #[inline]
@@ -553,6 +572,7 @@ mod tests {
     #[cfg(not(target_arch = "wasm32"))]
     use std::time::{Duration, Instant};
 
+    #[cfg(feature = "mock")]
     #[test]
     #[cfg_attr(
         all(target_arch = "wasm32", target_os = "unknown"),


### PR DESCRIPTION
The `CLOCK_OVERRIDE` adds overhead to all `Instant::now` calls, and is unused if `Clock::mock` is unused. Add a feature to allow users to disable it.