### PR TITLE
fix: support monotonic clock on Emscripten

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,17 @@ jobs:
       run: curl https://wasmtime.dev/install.sh -sSf | bash
     - name: Run Tests
       run: cargo wasi test
+  check-emscripten:
+    name: Check wasm32-unknown-emscripten
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install Rust Stable
+      run: rustup default stable
+    - name: Install wasm32-unknown-emscripten target
+      run: rustup target add wasm32-unknown-emscripten
+    - name: Check Emscripten target
+      run: cargo check --target wasm32-unknown-emscripten
   docs:
     runs-on: ubuntu-latest
     env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ raw-cpuid = "11.0"
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 raw-cpuid = "11.0"
 
-[target.'cfg(not(any(target_os = "windows", target_arch = "wasm32")))'.dependencies]
+[target.'cfg(any(target_os = "emscripten", not(any(target_os = "windows", target_arch = "wasm32"))))'.dependencies]
 libc = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/src/clocks/monotonic/mod.rs
+++ b/src/clocks/monotonic/mod.rs
@@ -13,7 +13,13 @@ mod wasm_wasi;
 #[cfg(all(target_arch = "wasm32", target_os = "wasi"))]
 pub use self::wasm_wasi::Monotonic;
 
-#[cfg(not(any(target_os = "windows", target_arch = "wasm32")))]
+#[cfg(any(
+    target_os = "emscripten",
+    not(any(target_os = "windows", target_arch = "wasm32"))
+))]
 mod unix;
-#[cfg(not(any(target_os = "windows", target_arch = "wasm32")))]
+#[cfg(any(
+    target_os = "emscripten",
+    not(any(target_os = "windows", target_arch = "wasm32"))
+))]
 pub use self::unix::Monotonic;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,8 @@
 //! `wasm32-unknown-unknown` target in browsers, `quanta` will use [window.performance.now] as a
 //! clock. This mean the accuracy is limited to milliseconds instead of the usual nanoseconds on
 //! other targets. When running within a WASI environment (target `wasm32-wasi`), the accuracy of
-//! the clock depends on the VM implementation.
+//! the clock depends on the VM implementation. On `wasm32-unknown-emscripten`, `quanta` uses
+//! Emscripten's POSIX-compatible monotonic clock.
 //!
 //! # TSC Support
 //!


### PR DESCRIPTION
I work at Cloudflare, where we’re exploring running Rust on Node.JS with the wasm32-unknown-emscripten target. 

While integrating tokio-quiche, I found that quanta does not compile for this target because no Monotonic implementation is selected.
Emscripten provides a POSIX-compatible clock_gettime, so this change routes Emscripten through the existing Unix implementation and enables its libc dependency.

I’ve verified this with cargo check --target wasm32-unknown-emscripten and end-to-end in our QUIC/HTTP/3 application.
I’d really appreciate having this supported upstream. Thanks for maintaining quanta and for taking a look!