### PR TITLE
fix: 32-bit: cannot construct `timespec` with struct literal syntax due to private fields

### DIFF
--- a/src/clocks/monotonic/unix.rs
+++ b/src/clocks/monotonic/unix.rs
@@ -6,10 +6,7 @@ pub struct Monotonic {
 impl Monotonic {
     #[allow(clippy::cast_sign_loss)]
     pub fn now(self) -> u64 {
-        let mut ts = libc::timespec {
-            tv_sec: 0,
-            tv_nsec: 0,
-        };
+        let mut ts = libc::timespec::default();
         unsafe {
             libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts);
         }


### PR DESCRIPTION
Resolves https://github.com/metrics-rs/quanta/issues/119